### PR TITLE
Fix: command prefix bug

### DIFF
--- a/src/main/java/me/bebeli555/cookieclient/Commands.java
+++ b/src/main/java/me/bebeli555/cookieclient/Commands.java
@@ -32,8 +32,8 @@ public class Commands extends Mod {
 		if (message.startsWith(prefix)) {
 			e.setCanceled(true);
 			mc.ingameGUI.getChatGUI().addToSentMessages(messageReal);
-			message = message.replace(prefix, "");
-			
+			message = message.substring(prefix.length());
+
 			//Open gui command
 			if (message.equals("gui")) {
 				openGui = true;


### PR DESCRIPTION
**Cap with a K** said that he broke the thing when he set the prefix to "g" he couldn't use `ggui` command
I discovered that it's a very easy to fix bug.
the old code replace the command prefix with "", in this case it will replace every "g" in the message
cause `ggui` to turn into `ui` instead of an expected `gui`

so I replace `message.replace(prefix, "")` to `message.substring(prefix.length())` and this seem to fix the problem